### PR TITLE
Use Nexus Gemfile Source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://artifacts.dox.support/repository/gems"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       redis (< 5)
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://artifacts.dox.support/repository/gems/
   specs:
     actionpack (6.1.4.7)
       actionview (= 6.1.4.7)


### PR DESCRIPTION
Auto-created Jira Issue: https://doximity.atlassian.net/browse/APPSEC-1249

---

## Summary

This change updates the Gemfile to use our nexus rubygems repository cache/mirror instead of the public rubygems.org or other sources.

## Details

This will also update any sub-repositories to use the default one. The sub-reposotories in nexus used to be required but are not any more, so we can simplify by using the main one for everything. For example, `https://artifacts.dox.support/repository/gems_contribsys_proxy` is no longer necessary and the standard `https://artifacts.dox.support/repository/gems` can be used for everything.

## QA

no-qa. This only affects where our gems are sourced from. As long as `bundle install` still works (which will be proved by ci tests), this is a safe change.

[_Created by Sourcegraph batch change `jgran/nexus-gemfile-source`._](https://sourcegraph.build.dox.pub/users/jgran/batch-changes/nexus-gemfile-source)
