### PR TITLE
Ignore Redis dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Redis
+dump.rdb


### PR DESCRIPTION
## Overview

`dump.rdb` is created if Redis is run locally (i.e., `redis-server`).  This PR ignores that file as it should not be committed.