### PR TITLE
Add `rake console`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,8 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+desc "Run a REPL with access to this library"
+task :console do
+  sh("irb -I lib -r super_spreader")
+end

--- a/lib/super_spreader/spread_tracker.rb
+++ b/lib/super_spreader/spread_tracker.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "redis"
 
 module SuperSpreader

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require "bundler/setup"
 require "super_spreader"
 
 require "active_job/test_helper"
-require "active_record"
 require "active_support/testing/time_helpers"
 require "factory_bot"
 require "pry"


### PR DESCRIPTION
Like `rails console`, but for a REPL with this library loaded from `lib` (not an installed version of the gem)