### PR TITLE
Rename model_class to be specific to SuperSpreader

### DIFF
--- a/lib/super_spreader/scheduler_config.rb
+++ b/lib/super_spreader/scheduler_config.rb
@@ -50,7 +50,7 @@ module SuperSpreader
     end
 
     def super_spreader_config
-      [job_class, job_class.model_class]
+      [job_class, job_class.super_spreader_model_class]
     end
 
     def spread_options

--- a/spec/integration/backfill_spec.rb
+++ b/spec/integration/backfill_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Integration" do
 
   describe ExampleBackfillJob do
     it "has SuperSpreader support" do
-      expect(described_class.model_class).to eq(ExampleModel)
+      expect(described_class.super_spreader_model_class).to eq(ExampleModel)
     end
 
     it "sets values on instances" do

--- a/spec/support/example_backfill_job.rb
+++ b/spec/support/example_backfill_job.rb
@@ -13,7 +13,7 @@ class ExampleBackfillJob < ActiveJob::Base
 
   # This is the model class that will be used when tracking the spread of jobs.
   # It is expected to be an ActiveRecord class.
-  def self.model_class
+  def self.super_spreader_model_class
     ExampleModel
   end
 


### PR DESCRIPTION
Closes https://github.com/doximity/super_spreader/issues/12

(Please read the issue for additional context.)

This is a breaking change to the previous `model_class` method name.  The intention is to have a more future-proof name before the first public release.