### PR TITLE
Swap artifact_publishing CI Context for nexus_readonly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
           pre_release: true
           requires:
             - pre-release-approval
-          context: artifact_publishing
+          context: nexus_readonly
 
   final-release:
     jobs:
@@ -142,4 +142,4 @@ workflows:
           pre_release: false
           requires:
             - gem-build
-          context: artifact_publishing
+          context: nexus_readonly


### PR DESCRIPTION
# `artifact_publishing` context is being retired
 We are replacing it with nexus_readonly to reduce our footprint of secrets stored in CircleCI. 
 If the CI workflows don't need anything other than bundle/docker/yarn, this should be sufficient.

[_Created by Sourcegraph batch change `anovadox/nexus-readonly`._](https://sourcegraph.build.dox.pub/users/anovadox/batch-changes/nexus-readonly)