### PR TITLE
Update gem GH workflows to latest editions

### DIFF
--- a/.github/workflows/gem_create_bump_version_pr.yml
+++ b/.github/workflows/gem_create_bump_version_pr.yml
@@ -1,0 +1,24 @@
+name: "▶️ Create bump version PR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type"
+        required: true
+        default: "minor"
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  open_pull_request:
+    uses: doximity/dox-gh-shared-workflows/.github/workflows/gem_create_bump_version_pr.yml@master
+    with:
+      release_type: ${{ github.event.inputs.release_type }}
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/gem_final_release.yml
+++ b/.github/workflows/gem_final_release.yml
@@ -1,0 +1,19 @@
+name: "🤖▶️ Create final release"
+
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  final-release:
+    if: (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+        (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'gem-release-automation'))
+    uses: doximity/dox-gh-shared-workflows/.github/workflows/gem_final_release.yml@master
+    with:
+      ruby_version: "3.1"
+      create-release: true
+    permissions:
+      contents: write
+    secrets: inherit

--- a/.github/workflows/gem_pre_release.yml
+++ b/.github/workflows/gem_pre_release.yml
@@ -1,0 +1,25 @@
+name: "▶️ Create pre release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ruby_version:
+        description: Ruby version for build to use
+        required: false
+        type: string
+        default: "3.1"
+      create-release:
+        description: Create a Github Release?
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  pre-release:
+    uses: doximity/dox-gh-shared-workflows/.github/workflows/gem_pre_release.yml@master
+    with:
+      ruby_version: ${{ inputs.ruby_version }}
+      create-release: ${{ inputs.create-release }}
+    permissions:
+      contents: write
+    secrets: inherit


### PR DESCRIPTION
Work item: [CSMS-845]

Overview
--------
Upgrade gem release workflows with recent improvements.

These workflows are already in use in `dox-messaging`.
See the following list for the improvements:
  - https://github.com/doximity/dox-gh-shared-workflows/pull/65
  - https://github.com/doximity/dox-gh-shared-workflows/pull/66
  - https://github.com/doximity/dox-gh-shared-workflows/pull/67

Wiki: https://wiki.doximity.com/articles/streamlined-gem-releases-github-actions-workflow

#NOQA

[_Created by Sourcegraph batch change `jvortmann/update-gem-release-workflows`._](https://sourcegraph.build.dox.pub/users/jvortmann/batch-changes/update-gem-release-workflows)

[CSMS-845]: https://doximity.atlassian.net/browse/CSMS-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ