### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 0.2.0
+
+* First release (see also #53)
+
 ## 0.1.0.beta2
 
 * First external release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## 0.2.0
 
 * First release (see also #53)
+* Resolve open Dependabot alerts (no changes for clients of this gem)
 
 ## 0.1.0.beta2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    super_spreader (0.1.0.beta2)
+    super_spreader (0.2.0)
       activejob (>= 6.1, < 8.0)
       activemodel (>= 6.1, < 8.0)
       activerecord (>= 6.1, < 8.0)

--- a/lib/super_spreader/version.rb
+++ b/lib/super_spreader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SuperSpreader
-  VERSION = "0.1.0.beta2"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Overview

We have released [v0.1.0.beta2 to RubyGems](https://rubygems.org/gems/super_spreader/versions/0.1.0.beta2), but do not yet have a stable release.  This PR creates a stable release.

## Technical Details

When we first reserved `super_spreader` as a gem name, we used version [v0.1.0](https://rubygems.org/gems/super_spreader/versions/0.1.0).  This empty gem precludes our ability to release as v0.1.0.  As a result, the first release with content is v0.2.0.