### PR TITLE
Version Health GHA Workflow - EOL reminders on PRs

### DIFF
--- a/.github/workflows/version_health.yml
+++ b/.github/workflows/version_health.yml
@@ -1,0 +1,19 @@
+name: "Version Health Report"
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  schedule:
+    - cron: '37 13 * * 1-5'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  version_health:
+    uses: doximity/dox-gh-shared-workflows/.github/workflows/version_health.yml@master
+    with:
+      primary_branch: ${{github.event.repository.default_branch}}
+    secrets: inherit


### PR DESCRIPTION
Auto-created Jira Issue: https://doximity.atlassian.net/browse/IA-2261

---

# Version Health Workflow
It will provide timely reminders on the project about the version of ruby, rails, and node currently in use, and their end of life dates.
- [Dox Wiki](https://wiki.doximity.com/articles/version-health-workflow)
- [Github](https://github.com/doximity/dox-gh-shared-workflows#version-health-comment-documentation)

![image](https://github.com/doximity/dox-gh-shared-workflows/assets/33638031/8fcf3513-82d8-4502-a782-209864b0df1a)

# Why this workflow is being added
Reminding devs about EOL dates is usually enough for the dependencies to get updated in time.

[_Created by Sourcegraph batch change `anovadox/version-health-gha`._](https://sourcegraph.build.us-east-1.internal.doximity.company/users/anovadox/batch-changes/version-health-gha)
