### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.8
-before_install: gem install bundler -v 1.17.2


### PR DESCRIPTION
This was added when the gem was generated.  I am not aware of us ever using Travis CI for this project.