### PR TITLE
Recommend ENV.fetch to fail fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ For Rails, please set up SuperSpreader using an initializer:
 # config/initializers/super_spreader.rb
 
 SuperSpreader.logger = Rails.logger
-SuperSpreader.redis = Redis.new(url: ENV["REDIS_URL"])
+SuperSpreader.redis = Redis.new(url: ENV.fetch("REDIS_URL"))
 ```
 
 ## Roadmap


### PR DESCRIPTION
Related: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FetchEnvVar

Aside: we should have Rubocop on this repository (though it wouldn't have caught this in the README).  That is tracked as https://github.com/doximity/super_spreader/issues/65