### PR TITLE
Deprecate SuperSpreader::StopSignal and related methods

### DIFF
--- a/lib/super_spreader/stop_signal.rb
+++ b/lib/super_spreader/stop_signal.rb
@@ -3,15 +3,21 @@
 require "redis"
 
 module SuperSpreader
+  # @deprecated Please use TrackBallast::StopSignal instead
   module StopSignal
+    # @deprecated Please use {TrackBallast::StopSignal.stop!} instead
     def stop!
+      warn "DEPRECATION WARNING: the class SuperSpreader::StopSignal is deprecated and will be removed in v1.0. " \
+        "Use TrackBallast::StopSignal instead."
       redis.set(stop_key, true)
     end
 
+    # @deprecated Please use {TrackBallast::StopSignal.go!} instead
     def go!
       redis.del(stop_key)
     end
 
+    # @deprecated Please use {TrackBallast::StopSignal.stopped?} instead
     def stopped?
       redis.exists(stop_key).positive?
     end


### PR DESCRIPTION
This is step 1 in an effort (see #66) to port `StopSignal` to our TrackBallast library (see [track_ballast#19](https://github.com/doximity/track_ballast/issues/19)).

There will be a followup PR to officially replace it.